### PR TITLE
redirect backend deafult url to dev page

### DIFF
--- a/backend/gis_project/urls.py
+++ b/backend/gis_project/urls.py
@@ -15,9 +15,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.shortcuts import redirect
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
+    path("", lambda _: redirect("https://dev.disfactory.tw/")),
 ]


### PR DESCRIPTION
 `/` redirect 到 https://dev.disfactory.tw/

fixed #81 