### PR TITLE
Fix center pointer positioning

### DIFF
--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -232,11 +232,11 @@ export default createComponent({
   border: solid 2px white;
 
   position: fixed;
-  top: 0;
+  top: 50%;
   left: 0;
   z-index: 2;
 
-  transform: translate(calc(50vw - 12.5px), calc(50vh - 12.5px + 47px - 25px));
+  transform: translate(calc(50vw - 12.5px), 12.5px);
 }
 
 .popup {


### PR DESCRIPTION
related to #76 

手機版 safari 高度不能用 vh 去對要用 % 去對