### PR TITLE
Activate django via gunicorn on middle2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: python3 ./manage.py migrate
-web: python3 ./manage.py runserver 0.0.0.0:80 --noreload > /srv/logs/web.log 2>&1 &
+web: cd backend && gunicorn -c gunicorn.conf.py gis_project.wsgi -b 0.0.0.0:80 > /srv/logs/web.log &


### PR DESCRIPTION
This PR will activate django server via gunicorn instead of runserver.
The code has been deployed to middle2 and work as usual for now. XD