### PR TITLE
Fix popup state refreshing

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -18,12 +18,12 @@
     <safety-modal :open="modalState.safetyModalOpen" :dismiss="modalActions.closeSafetyModal" />
 
     <Map
-      :openCreateFactoryForm="openCreateFactoryForm"
-      :openEditFactoryForm="openEditFactoryForm"
+      :openCreateFactoryForm="appActions.openCreateFactoryForm"
+      :openEditFactoryForm="appActions.openEditFactoryForm"
       :selectFactoryMode="appState.selectFactoryMode"
-      :enterSelectFactoryMode="enterSelectFactoryMode"
-      :exitSelectFactoryMode="exitSelectFactoryMode"
-      :setFactoryLocation="setFactoryLocation"
+      :enterSelectFactoryMode="appActions.enterSelectFactoryMode"
+      :exitSelectFactoryMode="appActions.exitSelectFactoryMode"
+      :setFactoryLocation="appActions.setFactoryLocation"
       :openFilterModal="modalActions.openFilterModal"
     />
 
@@ -32,10 +32,10 @@
 
       :mode="appState.formMode"
       :factoryData="appState.factoryData"
-      :close="closeFactoryPage"
+      :close="appActions.closeFactoryPage"
       :selectFactoryMode="appState.selectFactoryMode"
-      :enterSelectFactoryMode="enterSelectFactoryMode"
-      :exitSelectFactoryMode="exitSelectFactoryMode"
+      :enterSelectFactoryMode="appActions.enterSelectFactoryMode"
+      :exitSelectFactoryMode="appActions.exitSelectFactoryMode"
       :factoryLocation="appState.factoryLocation"
       :setCreateFactorySuccessModal="setCreateFactorySuccessModal"
     />
@@ -66,6 +66,7 @@ import { FactoryData } from './types'
 import { provideModalState, useModalState } from './lib/hooks'
 import { providePopupState } from './lib/factoryPopup'
 import { provideGA, useGA } from './lib/useGA'
+import { provideAppState, useAppState } from './lib/appState'
 
 export default createComponent({
   name: 'App',
@@ -86,6 +87,7 @@ export default createComponent({
   setup (_, context) {
     provideGA(context)
     providePopupState()
+    provideAppState()
 
     provideModalState()
     localStorage.setItem('use-app', 'true')
@@ -94,73 +96,20 @@ export default createComponent({
 
     const { pageview, event } = useGA()
 
-    const appState = reactive({
-      // Page state
-      // TODO: should be rewritten with vue router?
-      formMode: 'create',
-      factoryFormOpen: false,
-      factoryData: null as FactoryData | null,
-      factoryLocation: [] as number[],
-
-      // Map state
-      selectFactoryMode: false
-    })
-
-    // Form Editing functions
-    const openCreateFactoryForm = () => {
-      appState.factoryData = null
-      appState.formMode = 'create'
-      appState.factoryFormOpen = true
-      pageview('/create')
-    }
-
-    const openEditFactoryForm = (factory: FactoryData) => {
-      appState.factoryData = factory
-      appState.formMode = 'edit'
-      appState.factoryFormOpen = true
-      pageview('/edit')
-    }
-
-    function closeFactoryPage () {
-      appState.factoryFormOpen = false
-      event('closeFactoryPage')
-    }
-
-    const setFactoryLocation = (value: [number, number]) => {
-      appState.factoryLocation = value
-      event('setFactoryLocation')
-    }
-
-    function enterSelectFactoryMode () {
-      appState.selectFactoryMode = true
-      event('enterSelectFactoryMode')
-    }
-    function exitSelectFactoryMode () {
-      appState.selectFactoryMode = false
-      event('exitSelectFactoryMode')
-    }
+    const [appState, appActions] = useAppState()
 
     // register global accessible map instance
     provide(MainMapControllerSymbol, ref<MapFactoryController>(null))
 
     return {
       appState,
-
+      appActions,
       sidebarActions: [
         () => {},
         modalActions.openSafetyModal,
         modalActions.openContactModal,
         modalActions.openAboutModal
       ],
-
-      openCreateFactoryForm,
-      openEditFactoryForm,
-      closeFactoryPage,
-
-      enterSelectFactoryMode,
-      exitSelectFactoryMode,
-      setFactoryLocation,
-
       modalState,
       modalActions
     }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@
     <app-navbar :hide="appState.factoryFormOpen || appState.selectFactoryMode" :fixed="true" @menu="modalActions.toggleSidebar">農地違章工廠舉報</app-navbar>
     <app-sidebar v-model="modalState.sidebarOpen" :clickActions="sidebarActions" />
 
-    <filter-modal :open="appState.filterModalOpen" :dismiss="closeFilterModal" />
+    <filter-modal :open="modalState.filterModalOpen" :dismiss="modalActions.closeFilterModal" />
     <create-factory-success-modal
       :open="modalState.createFactorySuccessModal"
       :dismiss="modalActions.closeCreateFactorySuccessModal"
@@ -24,7 +24,7 @@
       :enterSelectFactoryMode="enterSelectFactoryMode"
       :exitSelectFactoryMode="exitSelectFactoryMode"
       :setFactoryLocation="setFactoryLocation"
-      :openFilterModal="openFilterModal"
+      :openFilterModal="modalActions.openFilterModal"
     />
 
     <form-page
@@ -95,9 +95,6 @@ export default createComponent({
     const { pageview, event } = useGA()
 
     const appState = reactive({
-      // Modal open states
-      filterModalOpen: false,
-
       // Page state
       // TODO: should be rewritten with vue router?
       formMode: 'create',
@@ -108,17 +105,6 @@ export default createComponent({
       // Map state
       selectFactoryMode: false
     })
-
-    // Modal state utilities
-    function closeFilterModal () {
-      event('closeFilterModal')
-      appState.filterModalOpen = false
-    }
-
-    function openFilterModal () {
-      event('openFilterModal')
-      appState.filterModalOpen = true
-    }
 
     // Form Editing functions
     const openCreateFactoryForm = () => {
@@ -166,10 +152,6 @@ export default createComponent({
         modalActions.openContactModal,
         modalActions.openAboutModal
       ],
-
-      // Modal state utilities
-      openFilterModal,
-      closeFilterModal,
 
       openCreateFactoryForm,
       openEditFactoryForm,

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -64,6 +64,7 @@ import { MapFactoryController } from './lib/map'
 import { MainMapControllerSymbol } from './symbols'
 import { FactoryData } from './types'
 import { provideModalState, useModalState } from './lib/hooks'
+import { providePopupState } from './lib/factoryPopup'
 import { provideGA, useGA } from './lib/useGA'
 
 export default createComponent({
@@ -84,6 +85,7 @@ export default createComponent({
   },
   setup (_, context) {
     provideGA(context)
+    providePopupState()
 
     provideModalState()
     localStorage.setItem('use-app', 'true')

--- a/frontend/src/components/AboutModal.vue
+++ b/frontend/src/components/AboutModal.vue
@@ -18,13 +18,13 @@
         <p>
           本系統感謝 g0v.tw 社群朋友共同開發。
         </p>
-        
+
         <p>
           既有疑似違章工廠資料來源為 2019 年 7 月 30 日取自內政部國土測繪圖資雲<a href="https://maps.nlsc.gov.tw/">網站</a>。
         </p>
-        
+
         <p>
-          全站使用者貢獻資料以 <a href="https://creativecommons.org/licenses/by/3.0/tw/">CC BY 姓名標示 3.0</a> 釋出，標註「© 農地違章工廠舉報小幫手貢獻者」，原始碼以 MIT 開放授權公開在 <a href="https://github.com/Disfactory/Disfactory">GitHub</a> 上 
+          全站使用者貢獻資料以 <a href="https://creativecommons.org/licenses/by/3.0/tw/">CC BY 姓名標示 3.0</a> 釋出，標註「© 農地違章工廠舉報小幫手貢獻者」，原始碼以 MIT 開放授權公開在 <a href="https://github.com/Disfactory/Disfactory">GitHub</a> 上
         </p>
       </div>
     </app-modal>

--- a/frontend/src/components/FormPage.vue
+++ b/frontend/src/components/FormPage.vue
@@ -372,10 +372,11 @@ export default createComponent({
           // TODO: refactor into sepearte method...
           try {
             const factory = { ...props.factoryData } as FactoryData
+            const images = _images as FactoryImage[]
 
-            factoryFormState.imageUrls = factoryFormState.imageUrls.concat((_images as FactoryImage[]).map(image => image.image_path))
+            factoryFormState.imageUrls = factoryFormState.imageUrls.concat(images.map(image => image.image_path))
 
-            factory.images = factory.images.concat(_images as FactoryImage[])
+            factory.images = factory.images.concat(images)
 
             if (mapController.value) {
               mapController.value.updateFactory(props.factoryData.id, factory)

--- a/frontend/src/components/FormPage.vue
+++ b/frontend/src/components/FormPage.vue
@@ -133,6 +133,7 @@ import { MainMapControllerSymbol } from '../symbols'
 import { useBackPressed } from '../lib/useBackPressed'
 import { useGA } from '@/lib/useGA'
 import { useModalState } from '../lib/hooks'
+import { useFactoryPopup } from '../lib/factoryPopup'
 
 export default createComponent({
   name: 'FormPage',
@@ -184,6 +185,7 @@ export default createComponent({
     const mapController = inject(MainMapControllerSymbol, ref<MapFactoryController>())
     let minimapController: MapFactoryController
     const [, modalActions] = useModalState()
+    const [popupState] = useFactoryPopup()
 
     const onBack = () => {
       if (mapController.value) {
@@ -295,6 +297,7 @@ export default createComponent({
 
         if (mapController.value) {
           mapController.value.updateFactory(factoryData.id, factory)
+          popupState.factoryData = factory
         }
         modalActions.openUpdateFactorySuccessModal()
       } catch (err) {
@@ -376,6 +379,7 @@ export default createComponent({
 
             if (mapController.value) {
               mapController.value.updateFactory(props.factoryData.id, factory)
+              popupState.factoryData = factory
             }
             modalActions.openUpdateFactorySuccessModal()
           } catch (err) {

--- a/frontend/src/components/FormPage.vue
+++ b/frontend/src/components/FormPage.vue
@@ -133,7 +133,7 @@ import { MainMapControllerSymbol } from '../symbols'
 import { useBackPressed } from '../lib/useBackPressed'
 import { useGA } from '@/lib/useGA'
 import { useModalState } from '../lib/hooks'
-import { useFactoryPopup } from '../lib/factoryPopup'
+import { useAppState } from '../lib/appState'
 
 export default createComponent({
   name: 'FormPage',
@@ -185,7 +185,7 @@ export default createComponent({
     const mapController = inject(MainMapControllerSymbol, ref<MapFactoryController>())
     let minimapController: MapFactoryController
     const [, modalActions] = useModalState()
-    const [popupState] = useFactoryPopup()
+    const [appState] = useAppState()
 
     const onBack = () => {
       if (mapController.value) {
@@ -297,7 +297,7 @@ export default createComponent({
 
         if (mapController.value) {
           mapController.value.updateFactory(factoryData.id, factory)
-          popupState.factoryData = factory
+          appState.factoryData = factory
         }
         modalActions.openUpdateFactorySuccessModal()
       } catch (err) {
@@ -379,7 +379,7 @@ export default createComponent({
 
             if (mapController.value) {
               mapController.value.updateFactory(props.factoryData.id, factory)
-              popupState.factoryData = factory
+              appState.factoryData = factory
             }
             modalActions.openUpdateFactorySuccessModal()
           } catch (err) {

--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -54,44 +54,17 @@
 <script lang="ts">
 import AppButton from '@/components/AppButton.vue'
 import AppNavbar from '@/components/AppNavbar.vue'
-import { createComponent, onMounted, ref, inject, reactive, computed } from '@vue/composition-api'
-import { initializeMap, MapFactoryController, getStatusBorderColor, getFactoryStatus } from '../lib/map'
+import { createComponent, onMounted, ref, inject, computed } from '@vue/composition-api'
+import { initializeMap, MapFactoryController, getFactoryStatus } from '../lib/map'
 import { getFactories } from '../api'
 import { MainMapControllerSymbol } from '../symbols'
 import { Overlay } from 'ol'
 import OverlayPositioning from 'ol/OverlayPositioning'
-import { FactoryStatus, FactoryData, FactoryStatusText, FACTORY_TYPE } from '../types'
+import { FactoryStatus } from '../types'
 import { useBackPressed } from '../lib/useBackPressed'
 import { useGA } from '@/lib/useGA'
 import { useModalState } from '../lib/hooks'
-
-const generateFactorySummary = (factory: FactoryData) => {
-  const imageStatus = factory.images.length > 0 ? '已有照片' : '缺照片'
-
-  const type = FACTORY_TYPE.find(type => type.value === factory.type)
-  let typeText: string = (type && type.text) || '其他'
-
-  if (typeText.includes('金屬')) {
-    typeText = '金屬'
-  }
-
-  return [
-    imageStatus,
-    typeText
-  ].filter(Boolean).join('\n')
-}
-
-const getPopupData = (factory: FactoryData) => {
-  const status = getFactoryStatus(factory)
-
-  return {
-    id: factory.id,
-    name: factory.name,
-    color: getStatusBorderColor(status),
-    status: FactoryStatusText[status][0],
-    summary: generateFactorySummary(factory),
-  }
-}
+import { useFactoryPopup, getPopupData } from '../lib/factoryPopup'
 
 export default createComponent({
   components: {
@@ -135,16 +108,9 @@ export default createComponent({
     const factoryValid = ref(false)
     const factoryLngLat = ref<number[]>([])
     const mapControllerRef = inject(MainMapControllerSymbol, ref<MapFactoryController>())
-    const [,modalActions] = useModalState()
+    const [, modalActions] = useModalState()
 
-    const popupState = reactive({
-      show: false,
-      factoryData: null
-    }) as {
-      show: boolean,
-      factoryData: FactoryData | null
-    }
-
+    const [popupState] = useFactoryPopup()
     const popupData = computed(() => popupState.factoryData ? getPopupData(popupState.factoryData) : {})
 
     const setPopup = (id: string) => {

--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -65,6 +65,7 @@ import { useBackPressed } from '../lib/useBackPressed'
 import { useGA } from '@/lib/useGA'
 import { useModalState } from '../lib/hooks'
 import { useFactoryPopup, getPopupData } from '../lib/factoryPopup'
+import { useAppState } from '../lib/appState'
 
 export default createComponent({
   components: {
@@ -108,27 +109,29 @@ export default createComponent({
     const factoryValid = ref(false)
     const factoryLngLat = ref<number[]>([])
     const mapControllerRef = inject(MainMapControllerSymbol, ref<MapFactoryController>())
+
     const [, modalActions] = useModalState()
+    const [appState, appActions] = useAppState()
 
     const [popupState] = useFactoryPopup()
-    const popupData = computed(() => popupState.factoryData ? getPopupData(popupState.factoryData) : {})
+    const popupData = computed(() => appState.factoryData ? getPopupData(appState.factoryData) : {})
 
     const setPopup = (id: string) => {
       if (!mapControllerRef.value) return
       const factory = mapControllerRef.value.getFactory(id)
 
       if (factory) {
-        popupState.factoryData = factory
+        appState.factoryData = factory
         popupState.show = true
       }
     }
 
     const onClickEditFactoryData = () => {
-      if (!popupState.factoryData) {
+      if (!appState.factoryData) {
         return
       }
 
-      props.openEditFactoryForm(popupState.factoryData)
+      props.openEditFactoryForm(appState.factoryData)
     }
 
     onMounted(() => {
@@ -218,11 +221,11 @@ export default createComponent({
       onClickCreateFactoryButton,
       onClickFinishSelectFactoryPositionButton,
       getButtonColorFromStatus: function () {
-        if (!popupState.factoryData) {
+        if (!appState.factoryData) {
           return 'default'
         }
 
-        const status = getFactoryStatus(popupState.factoryData)
+        const status = getFactoryStatus(appState.factoryData)
         return {
           [FactoryStatus.NEW]: 'blue',
           [FactoryStatus.EXISTING_INCOMPLETE]: 'gray',

--- a/frontend/src/lib/appState.ts
+++ b/frontend/src/lib/appState.ts
@@ -24,12 +24,14 @@ export const provideAppState = () => {
   return [appState]
 }
 
-type AppState = ReturnType<typeof provideAppState>[0]
-
 const registerMutator = (appState: AppState) => {
   const { event, pageview } = useGA()
 
   return {
+    updateFactoryData (factory: FactoryData) {
+      appState.factoryData = factory
+    },
+
     openCreateFactoryForm () {
       appState.factoryData = null
       appState.formMode = 'create'
@@ -66,7 +68,10 @@ const registerMutator = (appState: AppState) => {
   }
 }
 
-export const useAppState = () => {
+type AppState = ReturnType<typeof provideAppState>[0]
+type AppAction = ReturnType<typeof registerMutator>
+
+export const useAppState: () => [AppState, AppAction]= () => {
   const appState = inject(AppStateSymbol) as AppState
 
   return [appState, registerMutator(appState)]

--- a/frontend/src/lib/appState.ts
+++ b/frontend/src/lib/appState.ts
@@ -1,0 +1,73 @@
+import { inject, provide, reactive } from '@vue/composition-api'
+import { useGA } from './useGA'
+import { FactoryData } from '../types'
+
+const AppStateSymbol = Symbol('AppState')
+
+// A global state that can be shared across the entire application
+
+export const provideAppState = () => {
+  const appState = reactive({
+    // Page state
+    // TODO: should be rewritten with vue router?
+    formMode: 'create',
+    factoryFormOpen: false,
+    factoryData: null as FactoryData | null,
+    factoryLocation: [] as number[],
+
+    // Map state
+    selectFactoryMode: false
+  })
+
+  provide(AppStateSymbol, appState)
+
+  return [appState]
+}
+
+type AppState = ReturnType<typeof provideAppState>[0]
+
+const registerMutator = (appState: AppState) => {
+  const { event, pageview } = useGA()
+
+  return {
+    openCreateFactoryForm () {
+      appState.factoryData = null
+      appState.formMode = 'create'
+      appState.factoryFormOpen = true
+      pageview('/create')
+    },
+
+    openEditFactoryForm (factory: FactoryData) {
+      appState.factoryData = factory
+      appState.formMode = 'edit'
+      appState.factoryFormOpen = true
+      pageview('/edit')
+    },
+
+    closeFactoryPage () {
+      appState.factoryFormOpen = false
+      event('closeFactoryPage')
+    },
+
+    setFactoryLocation (value: [number, number]) {
+      appState.factoryLocation = value
+      event('setFactoryLocation')
+    },
+
+    enterSelectFactoryMode () {
+      appState.selectFactoryMode = true
+      event('enterSelectFactoryMode')
+    },
+
+    exitSelectFactoryMode () {
+      appState.selectFactoryMode = false
+      event('exitSelectFactoryMode')
+    }
+  }
+}
+
+export const useAppState = () => {
+  const appState = inject(AppStateSymbol) as AppState
+
+  return [appState, registerMutator(appState)]
+}

--- a/frontend/src/lib/factoryPopup.ts
+++ b/frontend/src/lib/factoryPopup.ts
@@ -6,17 +6,12 @@ const FactoryPopupSymbol = Symbol('FactoryPopup')
 
 export type FactoryPopupState = {
   show: boolean,
-  factoryData: FactoryData | null
 }
 
 export const providePopupState = () => {
   const popupState = reactive({
     show: false,
-    factoryData: null
-  }) as {
-    show: boolean,
-    factoryData: FactoryData | null
-  }
+  })
 
   provide(FactoryPopupSymbol, popupState)
 

--- a/frontend/src/lib/factoryPopup.ts
+++ b/frontend/src/lib/factoryPopup.ts
@@ -1,0 +1,58 @@
+import { provide, inject, reactive } from '@vue/composition-api'
+import { FactoryData, FACTORY_TYPE, FactoryStatusText } from '../types'
+import { getStatusBorderColor, getFactoryStatus } from './map'
+
+const FactoryPopupSymbol = Symbol('FactoryPopup')
+
+export type FactoryPopupState = {
+  show: boolean,
+  factoryData: FactoryData | null
+}
+
+export const providePopupState = () => {
+  const popupState = reactive({
+    show: false,
+    factoryData: null
+  }) as {
+    show: boolean,
+    factoryData: FactoryData | null
+  }
+
+  provide(FactoryPopupSymbol, popupState)
+
+  return [popupState]
+}
+
+export const useFactoryPopup = () => {
+  const popupState = inject(FactoryPopupSymbol) as FactoryPopupState
+
+  return [popupState]
+}
+
+const generateFactorySummary = (factory: FactoryData) => {
+  const imageStatus = factory.images.length > 0 ? '已有照片' : '缺照片'
+
+  const type = FACTORY_TYPE.find(type => type.value === factory.type)
+  let typeText: string = (type && type.text) || '其他'
+
+  if (typeText.includes('金屬')) {
+    typeText = '金屬'
+  }
+
+  return [
+    imageStatus,
+    typeText
+  ].filter(Boolean).join('\n')
+}
+
+export const getPopupData = (factory: FactoryData) => {
+  const status = getFactoryStatus(factory)
+
+  return {
+    id: factory.id,
+    name: factory.name,
+    color: getStatusBorderColor(status),
+    status: FactoryStatusText[status][0],
+    summary: generateFactorySummary(factory)
+  }
+}

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -32,7 +32,8 @@ export const provideModalState = () => {
     safetyModalOpen: false,
     gettingStartedModalOpen: localStorage.getItem('use-app') !== 'true',
 
-    sidebarOpen: false
+    sidebarOpen: false,
+    filterModalOpen: false,
   })
 
   provide(ModalStateSymbol, modalState)
@@ -48,7 +49,8 @@ type ModalState = {
   safetyModalOpen: boolean,
   gettingStartedModalOpen: boolean,
 
-  sidebarOpen: boolean
+  sidebarOpen: boolean,
+  filterModalOpen: boolean,
 }
 
 type ModalActions = {
@@ -70,7 +72,10 @@ type ModalActions = {
   openGettingStartedModal: Function,
   closeGettingStartedModal: Function,
 
-  toggleSidebar: Function
+  toggleSidebar: Function,
+
+  closeFilterModal: Function,
+  openFilterModal: Function,
 }
 
 export const useModalState: () => [ModalState, ModalActions] = () => {
@@ -101,6 +106,15 @@ export const useModalState: () => [ModalState, ModalActions] = () => {
     modalState.sidebarOpen = open
   }
 
+  const closeFilterModal = () => {
+    event('closeFilterModal')
+    modalState.filterModalOpen = false
+  }
+  const openFilterModal = () => {
+    event('openFilterModal')
+    modalState.filterModalOpen = true
+  }
+
   const modalActions = {
     openUpdateFactorySuccessModal,
     closeUpdateFactorySuccessModal,
@@ -120,7 +134,9 @@ export const useModalState: () => [ModalState, ModalActions] = () => {
     openGettingStartedModal,
     closeGettingStartedModal,
 
-    toggleSidebar
+    toggleSidebar,
+    openFilterModal,
+    closeFilterModal
   }
 
   return [modalState, modalActions]

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -41,17 +41,7 @@ export const provideModalState = () => {
   return modalState
 }
 
-type ModalState = {
-  updateFactorySuccessModal: boolean,
-  createFactorySuccessModal: boolean,
-  aboutModalOpen: boolean,
-  contactModalOpen: boolean,
-  safetyModalOpen: boolean,
-  gettingStartedModalOpen: boolean,
-
-  sidebarOpen: boolean,
-  filterModalOpen: boolean,
-}
+type ModalState = ReturnType<typeof provideModalState>
 
 type ModalActions = {
   openUpdateFactorySuccessModal: Function,

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -46,7 +46,7 @@ type ModalState = {
   aboutModalOpen: boolean,
   contactModalOpen: boolean,
   safetyModalOpen: boolean,
-  gettingStartedModalOpen: boolean
+  gettingStartedModalOpen: boolean,
 
   sidebarOpen: boolean
 }
@@ -68,7 +68,7 @@ type ModalActions = {
   closeSafetyModal: Function,
 
   openGettingStartedModal: Function,
-  closeGettingStartedModal: Function
+  closeGettingStartedModal: Function,
 
   toggleSidebar: Function
 }

--- a/frontend/src/lib/map.ts
+++ b/frontend/src/lib/map.ts
@@ -136,6 +136,12 @@ export class MapFactoryController {
 
   public updateFactory (id: string, factory: FactoryData) {
     this.factoryMap.set(id, factory)
+
+    // Update factory feature style base on new data
+    const feature = this.factoriesLayerSource.getFeatureById(id)
+    if (feature) {
+      feature.setStyle(this.getFactoryStyle(factory))
+    }
   }
 
   public addFactories (factories: FactoryData[]) {


### PR DESCRIPTION
fixes #183 (也就 6575824 這個 commit 相關而已)

試著用 provide/inject api 把一堆 global state 拆出來，讓他在另一個檔案亂（逃

順便用 global 的 factoryData state 把 popup 資料補充資料時不會更新的問題一併解掉