### PR TITLE
setup local mount for db data and backup path

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -22,3 +22,6 @@ GOOGLE_MAP_API_KEY=
 DISFACTORY_IMGUR_CLIENT_ID=your_imgur_id
 DISFACTORY_BACKEND_MEDIA_ROOT="./images/"
 DISFACTORY_BACKEND_DOMAIN="https://api.disfactory.tw/"
+
+DISFACTORY_PGDATA_PATH=/tmp/disfactory_data/
+DISFACTORY_PGDATA_BACKUP_PATH=/tmp/disfactory_db_dump/

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,5 @@
 .DEFAULT_GOAL := all
+-include $(ROOT_DIR)/.env
 
 .PHONY: unittest
 unittest:
@@ -18,6 +19,10 @@ run-dev:
 .PHONY: run-db
 run-db:
 	docker-compose -f docker-compose.dev.yml run --service-ports -d db
+
+.PHONY: run-db-backup
+run-db-backup:
+	docker-compose exec db bash -c 'pg_dump -d $(DISFACTORY_BACKEND_DEFAULT_DB_NAME) -U $(DISFACTORY_BACKEND_DEFAULT_DB_USER) -F t > /tmp/db_dump/`date +"%Y%m%d%H%M%S"`.tar'
 
 .PHONY: clean
 clean:

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -29,7 +29,8 @@ services:
   db:
     image: mdillon/postgis:11-alpine
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - ${DISFACTORY_PGDATA_PATH}:/var/lib/postgresql/data/
+      - ${DISFACTORY_PGDATA_BACKUP_PATH}:/tmp/db_dump/
     ports:
       - ${DISFACTORY_BACKEND_DEFAULT_DB_DEV_PORT}:5432
     environment:
@@ -60,5 +61,3 @@ services:
       - /bin/bash
       - -c
       - "/Disfactory/scripts/start_worker.sh"
-volumes:
-  postgres_data:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,8 +1,5 @@
 version: '3.7'
 
-volumes:
-  postgres_data:
-
 services:
   web:
     build:
@@ -31,7 +28,8 @@ services:
   db:
     image: mdillon/postgis:11-alpine
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - ${DISFACTORY_PGDATA_PATH}:/var/lib/postgresql/data/
+      - ${DISFACTORY_PGDATA_BACKUP_PATH}:/tmp/db_dump/
     environment:
       POSTGRES_DB: ${DISFACTORY_BACKEND_DEFAULT_DB_NAME}
       POSTGRES_USER: ${DISFACTORY_BACKEND_DEFAULT_DB_USER}


### PR DESCRIPTION
指定 db mount 到主機 local 的某個資料夾，並另外設定一個 backup 的 mount。

新增一個 make command 可以執行備份：
`make run-db-backup`
下了之後備份檔就會出現在 `DISFACTORY_PGDATA_BACKUP_PATH`