### PR TITLE
Fix #442 在工廠編輯頁面增加公文的連結，在公文的編輯頁面增加工廠的連結

### DIFF
--- a/backend/api/admin/document.py
+++ b/backend/api/admin/document.py
@@ -5,6 +5,8 @@ from api.admin.actions import ExportDocMixin
 from api.utils import set_function_attributes
 from import_export.admin import ImportExportModelAdmin
 from import_export import resources
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 
 class FollowUpInline(admin.StackedInline):
@@ -97,7 +99,10 @@ class DocumentAdmin(ImportExportModelAdmin, ExportDocMixin):
 
     @set_function_attributes(short_description="工廠號碼")
     def factory_display_number(self, obj):
-        return obj.factory.display_number
+        return mark_safe('<a href="{}">{}</a>'.format(
+            reverse("admin:api_factory_change", args=(obj.factory.id,)),
+            obj.factory.display_number
+        ))
 
     @set_function_attributes(short_description="鄉鎮市")
     def factory_townname(self, obj):

--- a/backend/api/admin/factory.py
+++ b/backend/api/admin/factory.py
@@ -1,3 +1,4 @@
+from api.models.document import Document
 from django.db.models import Max
 
 from django.contrib import admin
@@ -16,6 +17,8 @@ from api.utils import set_function_attributes
 from rangefilter.filter import DateRangeFilter
 from mapwidgets.widgets import GooglePointFieldWidget
 from import_export.admin import ImportExportModelAdmin
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 
 class FactoryWithReportRecords(DateRangeFilter):
@@ -112,6 +115,34 @@ class ReportRecordInline(admin.TabularInline):
         "id",
     )
     extra = 0
+
+class DocumentInline(admin.TabularInline):
+    model = Document
+    fields = (
+        "code_link",
+        "cet_staff",
+        "display_status",
+        "get_cet_next_tags"
+    )
+    readonly_fields = (
+        "code_link",
+        "cet_staff",
+        "display_status",
+        "get_cet_next_tags"
+    )
+    extra = 0
+
+    def code_link(self, obj):
+        return mark_safe('<a href="{}">{}</a>'.format(
+            reverse("admin:api_document_change", args=(obj.id,)),
+            obj.code
+        ))
+
+    def get_cet_next_tags(self, obj):
+        return ",".join([p.name for p in obj.cet_next_tags.all()])
+
+    def display_status(self, obj):
+        return ",".join([p.name for p in obj.display_status_tags.all()])
 
 
 class ImageInlineForFactory(admin.TabularInline):
@@ -219,7 +250,7 @@ class FactoryAdmin(
         ),
     )
 
-    inlines = [DescriptionInline, ImageInlineForFactory, ReportRecordInline]
+    inlines = [DescriptionInline, ImageInlineForFactory, ReportRecordInline, DocumentInline]
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)


### PR DESCRIPTION
Fix Issue #442 

在 factory change view 裡面列出該工廠的所有公文，並且使用者可以點擊公文文號開啟該公文的 document change view

![image](https://user-images.githubusercontent.com/126123/99952571-d378ac00-2dba-11eb-9858-d97da35c998d.png)

在 document change view 中，使用者可以點擊工廠名稱開啟該工廠的 factory change view

![image](https://user-images.githubusercontent.com/126123/99952694-0327b400-2dbb-11eb-8ded-c2a8860c088a.png)
