### PR TITLE
some deploy-friendly setting

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -27,3 +27,5 @@ DISFACTORY_PGDATA_PATH=/tmp/disfactory_data/
 DISFACTORY_PGDATA_BACKUP_PATH=/tmp/disfactory_db_dump/
 
 DISFACTORY_CADDY_STATIC_DIR=/tmp/disfactory/static
+
+COMPOSE_PROJECT_NAME=staging

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := all
--include $(ROOT_DIR)/.env
+-include .env
 
 .PHONY: unittest
 unittest:


### PR DESCRIPTION
- 用 `COMPOSE_PROJECT_NAME` 來分離不同的 deploy. Fixed #449 
- 讓 makefile 真正的讀到環境變數