### PR TITLE
修正輸出的公文，地段名稱未出現的問題 #457

### DIFF
--- a/backend/api/admin/actions/export_docx.py
+++ b/backend/api/admin/actions/export_docx.py
@@ -137,7 +137,7 @@ class FactoryReportDocumentWriter:
         self.document_model = model
         self.factory = model.factory
         self.document = document
-        self.factory_location = f"{self.factory.townname}({self.factory.sectcode}) {self.factory.landcode}"
+        self.factory_location = f"{self.factory.townname}{self.factory.sectname} ({self.factory.sectcode}) {self.factory.landcode}"
 
         self._generate_docx()
 
@@ -201,7 +201,7 @@ class FactoryReportDocumentWriter:
         # yapf: disable
         context = [
             '地址：10049台北市北平東路28號9樓之2',
-            '電話：02-23920371 ',
+            '電話：02-23920371',
             '傳真：02-23920381',
             '連絡人：{}'.format(sender_name),
             '電子信箱：eva@cet-taiwan.org'

--- a/backend/api/admin/actions/export_docx.py
+++ b/backend/api/admin/actions/export_docx.py
@@ -275,7 +275,7 @@ class FactoryReportDocumentWriter:
 
     def _cc(self, legislator):
         if self.factory.townname:
-            townname = self.factory.townname[:3]
+            townname = self.factory.townname.replace('臺灣省', '').replace('台灣省', '')[:3]
         else:
             townname = "UNKNOWN"
 


### PR DESCRIPTION
在輸出 docx 檔的時候，完整的工廠位置名稱應該是
`<factory.townname><factory.sectname> (<factory.sectcode>) <factory.landcode> 地號`

e.g. `新北市雙溪區牡丹里武丹坑段五分小段  (1481) 00180000 地號`

其中 `武丹坑段五分小段` 就是之前漏掉沒有加上的地段名稱