### PR TITLE
Fix #226 與 #384 提供 swagger 與 redoc 讓使用者比較方便了解 API 的使用方式

### DIFF
--- a/backend/api/views/factories_cr.py
+++ b/backend/api/views/factories_cr.py
@@ -171,6 +171,7 @@ def _handle_create_factory(request):
     operation_summary="新增指定 id 的工廠欄位資料",
     request_body=FactorySerializer,
     responses={200: openapi.Response("新增的工廠資料", FactorySerializer), 400: "request failed"},
+    auto_schema=None
 )
 @api_view(["GET", "POST"])
 def get_nearby_or_create_factories(request):

--- a/backend/api/views/factories_u.py
+++ b/backend/api/views/factories_u.py
@@ -94,6 +94,7 @@ def _handle_update_factory_attributes(request, factory_id):
     operation_summary="更新指定 id 的工廠資料",
     request_body=FactorySerializer,
     responses={200: openapi.Response("更新後的工廠資料", FactorySerializer), 400: "request failed"},
+    auto_schema=None
 )
 @api_view(["PUT", "GET"])
 def update_factory_attribute(request, factory_id):

--- a/backend/api/views/factory_image_c.py
+++ b/backend/api/views/factory_image_c.py
@@ -36,6 +36,7 @@ LOGGER = logging.getLogger("django")
         200: openapi.Response("圖片資料", ImageSerializer),
         400: "request failed",
     },
+    auto_schema=None
 )
 @api_view(["POST"])
 def post_factory_image_url(request, factory_id):

--- a/backend/api/views/image_c.py
+++ b/backend/api/views/image_c.py
@@ -42,6 +42,7 @@ LOGGER = logging.getLogger("django")
         ),
         400: "request failed",
     },
+    auto_schema=None
 )
 @api_view(["POST"])
 def post_image_url(request):

--- a/backend/api/views/miscellaneous/factory_image_c.py
+++ b/backend/api/views/miscellaneous/factory_image_c.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.db import transaction
 import django_q.tasks
+from drf_yasg.utils import swagger_auto_schema
 
 from rest_framework.decorators import api_view
 
@@ -21,6 +22,10 @@ from .utils import (
 LOGGER = logging.getLogger("django")
 
 
+@swagger_auto_schema(
+    method="post",
+    auto_schema=None
+)
 @api_view(["POST"])
 def post_factory_image(request, factory_id):
     client_ip = _get_client_ip(request)

--- a/backend/api/views/miscellaneous/image_c.py
+++ b/backend/api/views/miscellaneous/image_c.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 import django_q.tasks
 from rest_framework.decorators import api_view
+from drf_yasg.utils import swagger_auto_schema
 
 from api.models import Image
 from ..utils import _get_client_ip
@@ -18,6 +19,10 @@ from .utils import (
 LOGGER = logging.getLogger("django")
 
 
+@swagger_auto_schema(
+    method="post",
+    auto_schema=None
+)
 @api_view(["POST"])
 def post_image(request):
     client_ip = _get_client_ip(request)


### PR DESCRIPTION
提供 swagger 與 redoc 頁面，讓使用者可以比較方便理解 API 的使用方式
另外為了避免 API 太容易被攻擊，所以不顯示 Create 與 Update 的 API

![image](https://user-images.githubusercontent.com/126123/103355231-b71e0c80-4ae8-11eb-8f6f-02782e899403.png)
