### PR TITLE
set on_delete for Factory related models

### DIFF
--- a/backend/api/models/document.py
+++ b/backend/api/models/document.py
@@ -65,7 +65,8 @@ class Document(SoftDeleteMixin):
     code = models.IntegerField(verbose_name="公文號")
     factory = models.ForeignKey(
         Factory,
-        on_delete=models.PROTECT,
+        null=True,
+        on_delete=models.SET_NULL,
         related_name="documents",
     )
     creator = models.ForeignKey(

--- a/backend/api/models/image.py
+++ b/backend/api/models/image.py
@@ -17,14 +17,14 @@ class Image(SoftDeleteMixin):
     )
     factory = models.ForeignKey(
         Factory,
-        on_delete=models.PROTECT,
+        on_delete=models.CASCADE,
         related_name="images",
         blank=True,
         null=True,
     )
     report_record = models.ForeignKey(
         ReportRecord,
-        on_delete=models.PROTECT,
+        on_delete=models.CASCADE,
         related_name="images",
         blank=True,
         null=True,

--- a/backend/api/models/review.py
+++ b/backend/api/models/review.py
@@ -19,7 +19,7 @@ class Review(SoftDeleteMixin):
         Factory,
         null=True,
         blank=True,
-        on_delete=models.SET_NULL,
+        on_delete=models.CASCADE,
         related_name="reviews",
     )
     created_at = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
```
Image --> ReportRecord --> Factory
    |                         ^
    --------------------------
```

~Image 對 ReportRecord 設 restrict，如果刪 ReportRecord 不是因為他的 Factory 會刪
會 raise 一個 error~
~目前還沒有刪 ReportRecord 的需求，先上比較保護性質的設定~

RESTRICT 要 Django 3.1 才有，故用 CASCADE

Document 部分，跟 deeper confirm 過先設 SET_NULL

