### PR TITLE
改善 `/api/statistics/factories?level=town` 的效能

### DIFF
--- a/backend/api/views/statistics_r.py
+++ b/backend/api/views/statistics_r.py
@@ -4,6 +4,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
 import datetime
 import time
+from django.db.models import Q
 
 from ..models import Factory, Document, Image, ReportRecord
 from ..models.document import DocumentDisplayStatusEnum
@@ -45,8 +46,7 @@ def _generate_factories_query_set(townname, source, display_status):
 
     # townname
     if townname:
-        queryset = queryset.filter(
-            townname__contains=townname)
+        queryset = queryset.filter(Q(townname__startswith=townname) | Q(townname__startswith=f"臺灣省{townname}"))
 
     # source
     if source is not None:
@@ -463,8 +463,7 @@ def get_statistics_total(request):
         result[city] = {}
 
         # factories
-        factories = Factory.objects.filter(
-            townname__contains=city)
+        factories = Factory.objects.filter(Q(townname__startswith=city) | Q(townname__startswith=f"臺灣省{city}"))
         result[city]["factories"] = factories.count()
 
         # report records


### PR DESCRIPTION
因為有些 factories 的 towname 開頭是 `臺灣省花蓮縣` 有些則是 `花蓮縣` 
所以之前是使用 `contains` 的方式來搜尋 townname。
但是這個效能很差，所以改用兩個 `startswith` 的 filter 來處理，也就是同時搜尋 `臺灣省花蓮縣` 與 `花蓮縣` 
在我的電腦上這樣效能就可以從 14s 縮短到 4s 左右