### PR TITLE
fixed issue #527: doesn't update landcode when can't get landcode inf…

### DIFF
--- a/backend/api/admin/factory.py
+++ b/backend/api/admin/factory.py
@@ -290,15 +290,16 @@ class FactoryAdmin(
         try:
             landinfo = easymap.get_land_number(obj.lng, obj.lat)
             landcode = landinfo.get("landno")
+
+            obj.landcode = landcode
+            obj.sectno = landinfo.get("sectno")
+            obj.sectname = landinfo.get("sectName")
+            obj.towncode = landinfo.get("towncode")
+            obj.townname = landinfo.get("townname")
         except Exception as e:
             LOGGER.error("Can't get landcode from easymap")
             LOGGER.error(e)
 
-        obj.landcode = landcode
-        obj.sectno = landinfo.get("sectno")
-        obj.sectname = landinfo.get("sectName")
-        obj.towncode = landinfo.get("towncode")
-        obj.townname = landinfo.get("townname")
 
         super().save_model(request, obj, form, change)
 

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -47,17 +47,21 @@ def update_landcode(factory_id):
 
 def update_landcode_with_custom_factory_model(factory_id, factory_model):
     factory = factory_model.objects.get(pk=factory_id)
-    landinfo = easymap.get_land_number(factory.lng, factory.lat)
-    landcode = landinfo.get("landno")
+    try:
+        landinfo = easymap.get_land_number(factory.lng, factory.lat)
+        landcode = landinfo.get("landno")
 
-    LOGGER.info(f"Factory {factory_id} retrieved land number {landcode}")
-    factory_model.objects.filter(pk=factory_id).update(
-        landcode=landcode,
-        sectcode=landinfo.get("sectno"),
-        sectname=landinfo.get("sectName"),
-        towncode=landinfo.get("towncode"),
-        townname=landinfo.get("townname"),
-    )
+        LOGGER.info(f"Factory {factory_id} retrieved land number {landcode}")
+        factory_model.objects.filter(pk=factory_id).update(
+            landcode=landcode,
+            sectcode=landinfo.get("sectno"),
+            sectname=landinfo.get("sectName"),
+            towncode=landinfo.get("towncode"),
+            townname=landinfo.get("townname"),
+        )
+    except Exception as e:
+        LOGGER.error(f"update_landcode task failed.")
+        LOGGER.error(e)
 
 
 def upload_image(image_path, client_id, image_id):

--- a/backend/easymap.py
+++ b/backend/easymap.py
@@ -30,11 +30,11 @@ def get_point_city(sess, x, y, timeout=DEFAULT_TIMEOUT):
     data = {"wgs84x": x, "wgs84y": y}
     resp = sess.post(point_city_url, data=data, timeout=timeout)
     if resp.status_code != requests.codes.ok:
-        raise WebRequestError("Failed getting city code", resp.status_code, resp.text)
+        raise WebRequestError(f"Failed getting city code status_code:{resp.status_code}, text:{resp.text}")
     try:
         return resp.json()["cityCode"]
     except Exception:
-        raise WebRequestError("Failed parsing city code", resp.status_code, resp.text)
+        raise WebRequestError(f"Failed parsing city code text:{resp.text}", resp.text)
 
 
 def get_token(sess, timeout=DEFAULT_TIMEOUT):


### PR DESCRIPTION
因為 task 在 query easymap 失敗的時候，會每分鐘重新 query 一次。
不知道是否是這個原因現在 production 跟 staging 兩台機器現在 query easymap 都會取得一個 500 error。
所以現在 easymap 的 task 不會 raise exception 了，query 失敗就讓他失敗了。

然後在更新 factory 的時候，如果無法取得 easymap 的資訊，現在也不會 raise exception，就讓他不更新了 ...