### PR TITLE
Fix #556

### DIFF
--- a/backend/api/views/factories_cr.py
+++ b/backend/api/views/factories_cr.py
@@ -98,7 +98,7 @@ def _handle_create_factory(request):
             status=400,
         )
 
-    num = Factory.objects.aggregate(Max("display_number"))
+    num = Factory.raw_objects.aggregate(Max("display_number"))
 
     new_factory_field = {
         "name": post_body["name"],


### PR DESCRIPTION
Fix #556 
因為之前算 display_number 的時候沒有將被刪除的 factory 也列入計算
有可能會算出已經存在的 display_number
導致無法新增 factory （因為在 table 中 display_number 是不可重複的）

主要原因是刪除 Factory 的時候並不是真的刪除，而只是設定 deleted_at 的值
但是他依然存在於 table 內
