### PR TITLE
docs(docker-compose): update the test command

### DIFF
--- a/backend/docs/SETUP_COMPOSE.md
+++ b/backend/docs/SETUP_COMPOSE.md
@@ -39,7 +39,7 @@ docker-compose -f docker-compose.dev.yml up -d --build --force-recreate
 - Run tests
 
 ```bash
-docker-compose exec web python manage.py test
+docker-compose exec web pytest
 ```
 
 - Create admin user


### PR DESCRIPTION
According to c66fee554f4bf033fa776d9701334c860acb2bc1 , it seems the current unittest is launched by `pytest` instead of `manage.py test`.

# Steps to Test This Pull Request
1. Launch the dev environment with docker-compose, e.g. `make run-dev`
2. `docker-compose exec web pytest`

# Expected Result
`55 passed, 25 warnings`

# Additional Information
`docker-compose exec web python manage.py test` does not do anything. Its output is:

```
localhost,127.0.0.1
System check identified no issues (0 silenced).

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
```