### PR TITLE
Update easymap url to workaround easymap server error

### DIFF
--- a/backend/api/views/tests/test_easymap.py
+++ b/backend/api/views/tests/test_easymap.py
@@ -4,8 +4,8 @@ def test_get_land_number():
     # 120.1074406, 23.2353021
     # 臺南市北門區 溪底寮段三寮灣小段 (5404) 1681地號
     result = easymap.get_land_number(120.1074406, 23.2353021)
-    assert result["City"] == "D"
-    assert result["Area"] == "臺南市北門區"
+    assert result["towncode"] == "D24"
+    assert result["townname"] == "臺南市北門區"
     assert result["sectno"] == "5404"
     assert result["sectName"] == "溪底寮段三寮灣小段"
     assert result["landno"] == "1681"

--- a/backend/easymap.py
+++ b/backend/easymap.py
@@ -7,6 +7,8 @@ import towninfo
 
 DEFAULT_TIMEOUT = 5 # 5 seconds
 
+EASYMAP_BASE_URL = "https://easymap.land.moi.gov.tw/P02"
+
 class WebRequestError(RuntimeError):
     def __init__(self, message, status_code, response_body):
         super().__init__(message)
@@ -15,10 +17,10 @@ class WebRequestError(RuntimeError):
 
 
 def get_session(timeout=DEFAULT_TIMEOUT):
-    easymap_url = "https://easymap.land.moi.gov.tw/Index"
+    easymap_url = EASYMAP_BASE_URL + "/Index"
     sess = requests.Session()
     # XXX don't need this?
-    # sess.headers.update({"User-Agent": "Mozilla/5.0"})
+    sess.headers.update({"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36"})
     resp = sess.get(easymap_url, timeout=timeout)
     if "JSESSIONID" not in sess.cookies:
         raise WebRequestError("Failed getting session from easymap", resp.status_code, resp.text)
@@ -26,7 +28,7 @@ def get_session(timeout=DEFAULT_TIMEOUT):
 
 
 def get_point_city(sess, x, y, timeout=DEFAULT_TIMEOUT):
-    point_city_url = "https://easymap.land.moi.gov.tw/Query_json_getPointCity"
+    point_city_url = EASYMAP_BASE_URL + "/Query_json_getPointCity"
     data = {"wgs84x": x, "wgs84y": y}
     resp = sess.post(point_city_url, data=data, timeout=timeout)
     if resp.status_code != requests.codes.ok:
@@ -38,7 +40,7 @@ def get_point_city(sess, x, y, timeout=DEFAULT_TIMEOUT):
 
 
 def get_token(sess, timeout=DEFAULT_TIMEOUT):
-    set_token_url = "https://easymap.land.moi.gov.tw/pages/setToken.jsp"
+    set_token_url = EASYMAP_BASE_URL + "/pages/setToken.jsp"
     token_re = re.compile('<input type="hidden" name="(.*?)" value="(.*?)" />')
     resp = sess.post(set_token_url, timeout=timeout)
     if resp.status_code != requests.codes.ok:
@@ -50,8 +52,9 @@ def get_token(sess, timeout=DEFAULT_TIMEOUT):
 
 
 def get_door_info(sess, x, y, cityCode, token, timeout=DEFAULT_TIMEOUT):
-    get_door_info_url = "https://easymap.land.moi.gov.tw/Door_json_getDoorInfoByXY"
+    get_door_info_url = EASYMAP_BASE_URL + "/Door_json_getDoorInfoByXY"
     data = {"city": cityCode, "coordX": x, "coordY": y, **token}
+
     resp = sess.post(get_door_info_url, data=data, timeout=timeout)
     if resp.status_code != requests.codes.ok:
         raise WebRequestError("Failed getting door info", resp.status_code, resp.text)


### PR DESCRIPTION
easymap 原本用的 URL 會發生 `Opppps..網頁發生錯誤,請洽管理人員` 的錯誤，
因此換成 P02 系列手機用的網頁 URL 避免這個問題