### PR TITLE
prefetch follow_ups to reduce SQL queries

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -97,8 +97,10 @@ class FactorySerializer(ModelSerializer):
         return None
 
     def get_follow_ups_for_user(self, obj):
-        document_id_list = obj.documents.only("id")
-        follow_up_query_set = FollowUp.objects.filter(document__in=document_id_list, for_user=True)
+        follow_up_query_set = []
+        for document in obj.documents.all():
+            follow_up_query_set.extend(document.follow_ups.filter(for_user=True))
+
         note_list = list(map(lambda item: {
             "note": item.note,
             "created_at": item.created_at.isoformat(),

--- a/backend/api/views/utils.py
+++ b/backend/api/views/utils.py
@@ -41,7 +41,7 @@ def _get_nearby_factories(latitude, longitude, radius):
         .prefetch_related(Prefetch("images", queryset=Image.objects.only("id").all()))
         .prefetch_related(
             Prefetch(
-                "documents", queryset=Document.objects.only("created_at", "display_status").all()
+                "documents", queryset=Document.objects.only("created_at", "display_status").prefetch_related("follow_ups").all()
             )
         )
         .all()


### PR DESCRIPTION
先將 document 的 follow_up 讀出來，避免在 factory 量很大的時候，花費太多時間在查詢