### PR TITLE
Reduce the timeout duration for easymap and return empty sect land in…

### DIFF
--- a/backend/easymap.py
+++ b/backend/easymap.py
@@ -3,7 +3,7 @@
 import requests
 import re
 
-DEFAULT_TIMEOUT = 30  # 5 seconds
+DEFAULT_TIMEOUT = 5  # 5 seconds
 
 EASYMAP_BASE_URL = "http://oracle.code-life.info:3000"
 
@@ -64,7 +64,7 @@ def get_sectland_info(lat, lng):
         return SectLandInfo(sectname, sectcode, landcode)
     except Exception as e:
         print("Error: {}".format(e))
-        return TownInfo("", "", "")
+        return SectLandInfo("", "", "")
 
 
 def get_land_number(lat, lng, timeout=DEFAULT_TIMEOUT):


### PR DESCRIPTION
因為現在 easymap 的 server 反應比較快，所以縮短 timeout 時間。
並且在無法取得 easymap 資料時，回傳空的資料，避免後續動作無法繼續進行。