### PR TITLE
fix(ci): ensure workflow uses input commit SHA for Docker builds

### DIFF
--- a/.github/workflows/build-backend-image.yml
+++ b/.github/workflows/build-backend-image.yml
@@ -44,10 +44,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha || github.sha }}
 
       - name: Get commit SHA
         id: commit-info
-        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha=${{ github.event.inputs.commit_sha || github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -107,6 +109,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha || github.sha }}
 
       - name: Set deployment variables
         id: vars


### PR DESCRIPTION
## Summary
- Fixed issue where workflow_dispatch with specific commit SHA would still build Docker images from branch HEAD
- Updated checkout actions to use input commit SHA when provided
- Ensures Docker image tags match the actual commit being built

## Changes
- Modified build-backend-image.yml to checkout the specified commit SHA
- Updated both build and deploy jobs to use consistent commit references
- Docker images will now be tagged with the correct commit SHA

## Test plan
- [ ] Test workflow_dispatch with specific commit SHA
- [ ] Verify Docker images are built from correct commit
- [ ] Confirm image tags match specified commit SHA

🤖 Generated with [Claude Code](https://claude.ai/code)